### PR TITLE
Update AlertSystemExpiryDate to be nullable. 

### DIFF
--- a/Hackney.Shared.Asset/Domain/AssetCharacteristics.cs
+++ b/Hackney.Shared.Asset/Domain/AssetCharacteristics.cs
@@ -25,7 +25,7 @@ namespace Hackney.Shared.Asset.Domain
         public bool HasPrivateKitchen { get; set; }
         public int NumberOfKitchens { get; set; }
         public string Kitchenfloor { get; set; }
-        public DateTime AlertSystemExpiryDate { get; set; }
+        public DateTime? AlertSystemExpiryDate { get; set; }
         public string EpcScore { get; set; }
         public int NumberOfFloors { get; set; }
         public string AccessibilityComments { get; set; }


### PR DESCRIPTION
Some records have `AlertSystemExpiryDate` set to null in the database. This causes an exception in repairs when serializing the response.

I have updated the property to be a nullable dateTime.

![image](https://user-images.githubusercontent.com/88662046/218491253-8cf16e51-5e84-4d8f-92ca-9d33607f5488.png)