### PR TITLE
Added fluent validation to Edit Address boundary

### DIFF
--- a/Hackney.Shared.Asset.Tests/Boundary/Validation/EditAssetAddressRequestValidatorTests.cs
+++ b/Hackney.Shared.Asset.Tests/Boundary/Validation/EditAssetAddressRequestValidatorTests.cs
@@ -1,0 +1,163 @@
+﻿using AutoFixture;
+using FluentValidation.TestHelper;
+using Hackney.Shared.Asset.Boundary.Request;
+using Hackney.Shared.Asset.Boundary.Request.Validation;
+using Hackney.Shared.Asset.Domain;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Hackney.Shared.Asset.Tests.Boundary.Validation
+{
+    public class EditAssetAddressRequestValidatorTests
+    {
+        private readonly EditAssetAddressRequestValidator _sut;
+        private readonly Fixture _fixture = new Fixture();
+
+        public EditAssetAddressRequestValidatorTests()
+        {
+            _sut = new EditAssetAddressRequestValidator();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void MissingUprnShouldErrorWithNoValue(string value)
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.Uprn = value;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.Uprn)
+                .WithErrorCode(ErrorCodes.AssetAddressUprnEmptyOrInvalid);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void AddressLine1ShouldErrorWithNoValue(string value)
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.AddressLine1 = value;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.AddressLine1)
+                .WithErrorCode(ErrorCodes.AssetAddressLine1EmptyOrInvalid);
+        }
+
+        [Fact]
+        public void AddressLine1ShouldErrorWithXssTags()
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.AddressLine1 = StringWithTags;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.AddressLine1)
+                .WithErrorCode(ErrorCodes.XssFailure);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void AddressLine2ShouldNotErrorWithNoValue(string value)
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.AddressLine2 = value;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldNotHaveValidationErrorFor(x => x.AssetAddress.AddressLine2);
+        }
+
+        [Fact]
+        public void AddressLine2ShouldErrorWithXssTags()
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.AddressLine2 = StringWithTags;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.AddressLine2)
+                .WithErrorCode(ErrorCodes.XssFailure);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void AddressLine3ShouldNotErrorWithNoValue(string value)
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.AddressLine3 = value;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldNotHaveValidationErrorFor(x => x.AssetAddress.AddressLine3);
+        }
+
+        [Fact]
+        public void AddressLine3ShouldErrorWithXssTags()
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.AddressLine3 = StringWithTags;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.AddressLine3)
+                .WithErrorCode(ErrorCodes.XssFailure);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void AddressLine4ShouldNotErrorWithNoValue(string value)
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.AddressLine4 = value;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldNotHaveValidationErrorFor(x => x.AssetAddress.AddressLine4);
+        }
+
+        [Fact]
+        public void AddressLine4ShouldErrorWithXssTags()
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.AddressLine4 = StringWithTags;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.AddressLine4)
+                .WithErrorCode(ErrorCodes.XssFailure);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void PostCodeShouldErrorWithNoValue(string value)
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.PostCode = value;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.PostCode)
+                .WithErrorCode(ErrorCodes.AssetAddressPostcodeEmptyOrInvalid);
+        }
+
+        [Fact]
+        public void PostCodeShouldErrorWithXssTags()
+        {
+            var request = CreateValidRequest();
+            request.AssetAddress.PostCode = StringWithTags;
+
+            var result = _sut.TestValidate(request);
+            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.PostCode)
+                .WithErrorCode(ErrorCodes.XssFailure);
+        }
+
+
+        private EditAssetAddressRequest CreateValidRequest()
+        {
+            return new EditAssetAddressRequest()
+            {
+                AssetAddress = _fixture.Create<AssetAddress>()
+            };
+        }
+
+        private const string StringWithTags = "Some string with <tag> in it <script src='http://bad-actor.net/hijack.js'>.";
+    }
+}

--- a/Hackney.Shared.Asset/Boundary/Request/Validation/EditAssetAddressRequestValidator.cs
+++ b/Hackney.Shared.Asset/Boundary/Request/Validation/EditAssetAddressRequestValidator.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentValidation;
+using Hackney.Core.Validation;
+
+namespace Hackney.Shared.Asset.Boundary.Request.Validation
+{
+    public class EditAssetAddressRequestValidator : AbstractValidator<EditAssetAddressRequest>
+    {
+        public EditAssetAddressRequestValidator()
+        {
+            RuleFor(x => x.AssetAddress).NotNull()
+                                        .NotEmpty()
+                                        .WithErrorCode(ErrorCodes.AssetAddressEmptyOrInvalid);
+
+            RuleFor(x => x.AssetAddress).NotXssString()
+                                        .WithErrorCode(ErrorCodes.XssFailure);
+
+            RuleFor(x => x.AssetAddress.Uprn).NotNull()
+                                             .NotEmpty()
+                                             .WithErrorCode(ErrorCodes.AssetAddressUprnEmptyOrInvalid);
+
+            RuleFor(x => x.AssetAddress.Uprn).NotXssString()
+                                             .WithErrorCode(ErrorCodes.XssFailure);
+
+            RuleFor(x => x.AssetAddress.AddressLine1).NotNull()
+                                                     .NotEmpty()
+                                                     .WithErrorCode(ErrorCodes.AssetAddressLine1EmptyOrInvalid);
+
+            RuleFor(x => x.AssetAddress.AddressLine1).NotXssString()
+                                                     .WithErrorCode(ErrorCodes.XssFailure);
+
+            RuleFor(x => x.AssetAddress.AddressLine2).NotXssString()
+                                         .WithErrorCode(ErrorCodes.XssFailure);
+            RuleFor(x => x.AssetAddress.AddressLine3).NotXssString()
+                                         .WithErrorCode(ErrorCodes.XssFailure);
+            RuleFor(x => x.AssetAddress.AddressLine4).NotXssString()
+                                         .WithErrorCode(ErrorCodes.XssFailure);
+
+            RuleFor(x => x.AssetAddress.PostCode).NotNull()
+                                                 .NotEmpty()
+                                                 .WithErrorCode(ErrorCodes.AssetAddressPostcodeEmptyOrInvalid);
+
+            RuleFor(x => x.AssetAddress.PostCode).NotXssString()
+                                                 .WithErrorCode(ErrorCodes.XssFailure);
+        }
+    }
+}

--- a/Hackney.Shared.Asset/Boundary/Request/Validation/ErrorCodes.cs
+++ b/Hackney.Shared.Asset/Boundary/Request/Validation/ErrorCodes.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hackney.Shared.Asset.Boundary.Request.Validation
+{
+    public static class ErrorCodes
+    {
+        public const string AssetAddressEmptyOrInvalid = "AD1";
+        public const string AssetAddressLine1EmptyOrInvalid = "AD2";
+        public const string AssetAddressUprnEmptyOrInvalid = "AD3";
+        public const string AssetAddressPostcodeEmptyOrInvalid = "AD4";
+        public const string XssFailure = "W42";
+    }
+}


### PR DESCRIPTION
- As suggested by @humulla in https://github.com/LBHackney-IT/asset-information-api/pull/86, the boundary objects require validation
- Added validator for EditAssetAddressRequest
- Added tests to the same effect