### PR TITLE
MR-698 - Allow Asset properties to be nullable to avoid misleading default values

### DIFF
--- a/Hackney.Shared.Asset/Domain/AssetCharacteristics.cs
+++ b/Hackney.Shared.Asset/Domain/AssetCharacteristics.cs
@@ -4,9 +4,9 @@ namespace Hackney.Shared.Asset.Domain
 {
     public class AssetCharacteristics
     {
-        public int NumberOfBedrooms { get; set; }
-        public int NumberOfLifts { get; set; }
-        public int NumberOfLivingRooms { get; set; }
+        public int? NumberOfBedrooms { get; set; }
+        public int? NumberOfLifts { get; set; }
+        public int? NumberOfLivingRooms { get; set; }
         public string WindowType { get; set; }
         public string YearConstructed { get; set; }
         public string AssetPropertyFolderLink { get; set; }
@@ -14,26 +14,26 @@ namespace Hackney.Shared.Asset.Domain
         public DateTime? FireSafetyCertificateExpiryDate { get; set; }
         public DateTime? GasSafetyCertificateExpiryDate { get; set; }
         public DateTime? ElecCertificateExpiryDate { get; set; }
-        public bool HasStairs { get; set; }
-        public int NumberOfStairs { get; set; }
-        public bool HasRampAccess { get; set; }
-        public bool HasCommunalAreas { get; set; }
-        public bool HasPrivateBathroom { get; set; }
-        public int NumberOfBathrooms { get; set; }
+        public bool? HasStairs { get; set; }
+        public int? NumberOfStairs { get; set; }
+        public bool? HasRampAccess { get; set; }
+        public bool? HasCommunalAreas { get; set; }
+        public bool? HasPrivateBathroom { get; set; }
+        public int? NumberOfBathrooms { get; set; }
         public string BathroomFloor { get; set; }
-        public bool HasPrivateKitchen { get; set; }
-        public int NumberOfKitchens { get; set; }
+        public bool? HasPrivateKitchen { get; set; }
+        public int? NumberOfKitchens { get; set; }
         public string Kitchenfloor { get; set; }
         public DateTime? AlertSystemExpiryDate { get; set; }
         public string EpcScore { get; set; }
-        public int NumberOfFloors { get; set; }
+        public int? NumberOfFloors { get; set; }
         public string AccessibilityComments { get; set; }
-        public int NumberOfBedSpaces { get; set; }
-        public int NumberOfCots { get; set; }
+        public int? NumberOfBedSpaces { get; set; }
+        public int? NumberOfCots { get; set; }
         public string SleepingArrangementNotes { get; set; }
-        public int NumberOfShowers { get; set; }
+        public int? NumberOfShowers { get; set; }
         public string KitchenNotes { get; set; }
-        public bool IsStepFree { get; set; }
+        public bool? IsStepFree { get; set; }
         public string BathroomNotes { get; set; }
         public string LivingRoomNotes { get; set; }
     }

--- a/Hackney.Shared.Asset/Domain/AssetLocation.cs
+++ b/Hackney.Shared.Asset/Domain/AssetLocation.cs
@@ -5,7 +5,7 @@ namespace Hackney.Shared.Asset.Domain
     public class AssetLocation
     {
         public string FloorNo { get; set; }
-        public int TotalBlockFloors { get; set; }
+        public int? TotalBlockFloors { get; set; }
         public IEnumerable<ParentAsset> ParentAssets { get; set; }
     }
 }

--- a/Hackney.Shared.Asset/Domain/AssetManagement.cs
+++ b/Hackney.Shared.Asset/Domain/AssetManagement.cs
@@ -13,10 +13,10 @@ namespace Hackney.Shared.Asset.Domain
         public bool IsTMOManaged { get; set; }
         public string PropertyOccupiedStatus { get; set; }
         public string PropertyOccupiedStatusReason { get; set; }
-        public bool IsNoRepairsMaintenance { get; set; }
+        public bool? IsNoRepairsMaintenance { get; set; }
         public string CouncilTaxType { get; set; }
         public string CouncilTaxLiability { get; set; }
-        public bool IsTemporaryAccomodation { get; set; }
-        public bool ReadyToLetDate { get; set; }
+        public bool? IsTemporaryAccomodation { get; set; }
+        public bool? ReadyToLetDate { get; set; }
     }
 }

--- a/Hackney.Shared.Asset/Infrastructure/AssetDb.cs
+++ b/Hackney.Shared.Asset/Infrastructure/AssetDb.cs
@@ -24,7 +24,7 @@ namespace Hackney.Shared.Asset.Infrastructure
         public string RootAsset { get; set; }
 
         [DynamoDBProperty]
-        public bool IsActive { get; set; }
+        public bool? IsActive { get; set; }
 
         [DynamoDBProperty]
         public string ParentAssetIds { get; set; }


### PR DESCRIPTION
## Link to JIRA ticket

(https://hackney.atlassian.net/jira/software/c/projects/MR/boards/88?modal=detail&selectedIssue=MR-698)

## Describe this PR

### *What is the problem we're trying to solve*

While working on the New Asset Form (MMH) we've noticed that, when saving a new asset, a lot of other properties are added to it. 
An asset can have so many properties, however the New Asset Form only captures some of these. The issue is with the properties we're not capturing, especially the ones of type int and boolean, as a default value is assigned, which can be misleading for example:
`numberOfShowers` is saved with a `0` value or a boolean property such as `hasRampAccess` is saved as `false` - these are fields the values of which we're NOT capturing in the form, but if someone was to look at the asset in the database, they  would find misleading information.

For the above examples, as we're not capturing those properties (or they're optional in the form), we'd want their values to be null, rather than use default values (0s and false's).

### *What changes have we introduced*

- Set int and boolean properties within AssetCharacteristics to be nullable
- Set int TotalBlockFloors property in AssetLocation to be nullable
- Fields of boolean type in AssetManagement that are not captured by New Asset Form are now nullable. IsCouncilProperty and IsTMOManaged are required field so they will always have a valid value.
- IsActive in AssetDb is now nullable

### *Follow up actions after merging PR*

Continue work on PR https://github.com/LBHackney-IT/mtfh-frontend-property/pull/51