### PR TITLE
AssetDb IsActive property no longer nullable

### DIFF
--- a/Hackney.Shared.Asset/Boundary/Response/AssetResponseObject.cs
+++ b/Hackney.Shared.Asset/Boundary/Response/AssetResponseObject.cs
@@ -11,10 +11,8 @@ namespace Hackney.Shared.Asset.Boundary.Response
         public string AssetId { get; set; }
         public AssetType AssetType { get; set; }
         public string RootAsset { get; set; }
-
         public bool IsActive { get; set; }
         public string ParentAssetIds { get; set; }
-
         public AssetLocation AssetLocation { get; set; }
         public AssetAddress AssetAddress { get; set; }
         public AssetManagement AssetManagement { get; set; }

--- a/Hackney.Shared.Asset/Infrastructure/AssetDb.cs
+++ b/Hackney.Shared.Asset/Infrastructure/AssetDb.cs
@@ -24,7 +24,7 @@ namespace Hackney.Shared.Asset.Infrastructure
         public string RootAsset { get; set; }
 
         [DynamoDBProperty]
-        public bool? IsActive { get; set; }
+        public bool IsActive { get; set; }
 
         [DynamoDBProperty]
         public string ParentAssetIds { get; set; }


### PR DESCRIPTION
This is a follow up to PR #29. This PR got approved and merged, however, due to the branch name not following the correct naming convention, the update to Hackney.Asset.Shared was not published.

After some internal discussion we've agreed that all properties created via the 'new asset' form have to have their IsActive property set to 'true', which means there's no need to IsActive to be nullable (as changed in PR 29).

This PR sets IsActive back to what it was (non nullable) and should trigger a new version release of the package Hackney.Asset.Shared. 