### PR TITLE
Undo changes introduced by version 0.27 (nullable types removed from Asset)

### DIFF
--- a/Hackney.Shared.Asset/Domain/AssetCharacteristics.cs
+++ b/Hackney.Shared.Asset/Domain/AssetCharacteristics.cs
@@ -4,9 +4,9 @@ namespace Hackney.Shared.Asset.Domain
 {
     public class AssetCharacteristics
     {
-        public int? NumberOfBedrooms { get; set; }
-        public int? NumberOfLifts { get; set; }
-        public int? NumberOfLivingRooms { get; set; }
+        public int NumberOfBedrooms { get; set; }
+        public int NumberOfLifts { get; set; }
+        public int NumberOfLivingRooms { get; set; }
         public string WindowType { get; set; }
         public string YearConstructed { get; set; }
         public string AssetPropertyFolderLink { get; set; }
@@ -14,26 +14,26 @@ namespace Hackney.Shared.Asset.Domain
         public DateTime? FireSafetyCertificateExpiryDate { get; set; }
         public DateTime? GasSafetyCertificateExpiryDate { get; set; }
         public DateTime? ElecCertificateExpiryDate { get; set; }
-        public bool? HasStairs { get; set; }
-        public int? NumberOfStairs { get; set; }
-        public bool? HasRampAccess { get; set; }
-        public bool? HasCommunalAreas { get; set; }
-        public bool? HasPrivateBathroom { get; set; }
-        public int? NumberOfBathrooms { get; set; }
+        public bool HasStairs { get; set; }
+        public int NumberOfStairs { get; set; }
+        public bool HasRampAccess { get; set; }
+        public bool HasCommunalAreas { get; set; }
+        public bool HasPrivateBathroom { get; set; }
+        public int NumberOfBathrooms { get; set; }
         public string BathroomFloor { get; set; }
-        public bool? HasPrivateKitchen { get; set; }
-        public int? NumberOfKitchens { get; set; }
+        public bool HasPrivateKitchen { get; set; }
+        public int NumberOfKitchens { get; set; }
         public string Kitchenfloor { get; set; }
         public DateTime? AlertSystemExpiryDate { get; set; }
         public string EpcScore { get; set; }
-        public int? NumberOfFloors { get; set; }
+        public int NumberOfFloors { get; set; }
         public string AccessibilityComments { get; set; }
-        public int? NumberOfBedSpaces { get; set; }
-        public int? NumberOfCots { get; set; }
+        public int NumberOfBedSpaces { get; set; }
+        public int NumberOfCots { get; set; }
         public string SleepingArrangementNotes { get; set; }
-        public int? NumberOfShowers { get; set; }
+        public int NumberOfShowers { get; set; }
         public string KitchenNotes { get; set; }
-        public bool? IsStepFree { get; set; }
+        public bool IsStepFree { get; set; }
         public string BathroomNotes { get; set; }
         public string LivingRoomNotes { get; set; }
     }

--- a/Hackney.Shared.Asset/Domain/AssetLocation.cs
+++ b/Hackney.Shared.Asset/Domain/AssetLocation.cs
@@ -5,7 +5,7 @@ namespace Hackney.Shared.Asset.Domain
     public class AssetLocation
     {
         public string FloorNo { get; set; }
-        public int? TotalBlockFloors { get; set; }
+        public int TotalBlockFloors { get; set; }
         public IEnumerable<ParentAsset> ParentAssets { get; set; }
     }
 }

--- a/Hackney.Shared.Asset/Domain/AssetManagement.cs
+++ b/Hackney.Shared.Asset/Domain/AssetManagement.cs
@@ -13,10 +13,10 @@ namespace Hackney.Shared.Asset.Domain
         public bool IsTMOManaged { get; set; }
         public string PropertyOccupiedStatus { get; set; }
         public string PropertyOccupiedStatusReason { get; set; }
-        public bool? IsNoRepairsMaintenance { get; set; }
+        public bool IsNoRepairsMaintenance { get; set; }
         public string CouncilTaxType { get; set; }
         public string CouncilTaxLiability { get; set; }
-        public bool? IsTemporaryAccomodation { get; set; }
-        public bool? ReadyToLetDate { get; set; }
+        public bool IsTemporaryAccomodation { get; set; }
+        public bool ReadyToLetDate { get; set; }
     }
 }


### PR DESCRIPTION
Following PR https://github.com/LBHackney-IT/asset-information-api/pull/102 - this PR undoes what the following two PR did:

MR-698 - Allow Asset properties to be nullable to avoid misleading default values - https://github.com/LBHackney-IT/asset-shared/pull/29
MR-698 - AssetDb IsActive property no longer nullable - https://github.com/LBHackney-IT/asset-shared/pull/30

We have found that adding null types to Hackney.Asset.Shared package has introduced a few issues with the apps/solutions that use the current version of the package (0.27), that allows null values within an Asset.

For more context please read PR #29 's description.