### PR TITLE
Add temporary accommodation property type

### DIFF
--- a/Hackney.Shared.Asset/Domain/AssetManagement.cs
+++ b/Hackney.Shared.Asset/Domain/AssetManagement.cs
@@ -17,6 +17,7 @@ namespace Hackney.Shared.Asset.Domain
         public string CouncilTaxType { get; set; }
         public string CouncilTaxLiability { get; set; }
         public bool? IsTemporaryAccomodation { get; set; }
+        public string TemporaryAccommodationPropertyType { get; set; }
         public bool? ReadyToLetDate { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[HT20-644 - Backend changes to save TA property types.](https://hackney.atlassian.net/browse/HT20-644)

## Describe this PR

### *What is the problem we're trying to solve*

Allowing the Temporary Accommodation tool to have specific subtypes for a dwelling, relevant only to TA.

### *What changes have we introduced*

Add support to the asset API for the temporary accommodation specific property type, as exposed by the reference data API.

### *Follow up actions after merging PR*

Any projects (eg. API, listeners) that use this shared package should be updated.