### PR TITLE
Extend asset characteristics

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# Populate the Hackney Nuget package access token:
+LBHPACKAGESTOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Ankh.NoLoad
 
 #Other
 .svn
+.env
 
 # Include DLLs if they're in the NuGet packages directory
 !/packages/*/lib/*.dll

--- a/Hackney.Shared.Asset.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.Asset.Tests/Factories/EntityFactoryTest.cs
@@ -107,5 +107,172 @@ namespace Hackney.Shared.Asset.Tests.Factories
 
             entity.Should().BeEquivalentTo(databaseEntity);
         }
+
+        #region Asset Characteristics
+        private void StrictAssertDatabaseToDomainAssetCharacteristicMapping(AssetCharacteristicsDb databaseAC, AssetCharacteristics domainAC)
+        {
+            domainAC.NumberOfBedrooms.Should().Be(databaseAC.NumberOfBedrooms);
+            domainAC.NumberOfSingleBeds.Should().Be(databaseAC.NumberOfSingleBeds);
+            domainAC.NumberOfDoubleBeds.Should().Be(databaseAC.NumberOfDoubleBeds);
+            domainAC.NumberOfLifts.Should().Be(databaseAC.NumberOfLifts);
+            domainAC.NumberOfLivingRooms.Should().Be(databaseAC.NumberOfLivingRooms);
+            domainAC.WindowType.Should().Be(databaseAC.WindowType);
+            domainAC.YearConstructed.Should().Be(databaseAC.YearConstructed);
+            domainAC.AssetPropertyFolderLink.Should().Be(databaseAC.AssetPropertyFolderLink);
+            domainAC.EpcExpiryDate.Should().Be(databaseAC.EpcExpiryDate);
+            domainAC.FireSafetyCertificateExpiryDate.Should().Be(databaseAC.FireSafetyCertificateExpiryDate);
+            domainAC.GasSafetyCertificateExpiryDate.Should().Be(databaseAC.GasSafetyCertificateExpiryDate);
+            domainAC.ElecCertificateExpiryDate.Should().Be(databaseAC.ElecCertificateExpiryDate);
+            domainAC.HasStairs.Should().Be(databaseAC.HasStairs);
+            domainAC.NumberOfStairs.Should().Be(databaseAC.NumberOfStairs);
+            domainAC.HasRampAccess.Should().Be(databaseAC.HasRampAccess);
+            domainAC.HasCommunalAreas.Should().Be(databaseAC.HasCommunalAreas);
+            domainAC.HasPrivateBathroom.Should().Be(databaseAC.HasPrivateBathroom);
+            domainAC.NumberOfBathrooms.Should().Be(databaseAC.NumberOfBathrooms);
+            domainAC.BathroomFloor.Should().Be(databaseAC.BathroomFloor);
+            domainAC.HasPrivateKitchen.Should().Be(databaseAC.HasPrivateKitchen);
+            domainAC.NumberOfKitchens.Should().Be(databaseAC.NumberOfKitchens);
+            domainAC.Kitchenfloor.Should().Be(databaseAC.Kitchenfloor);
+            domainAC.AlertSystemExpiryDate.Should().Be(databaseAC.AlertSystemExpiryDate);
+            domainAC.EpcScore.Should().Be(databaseAC.EpcScore);
+            domainAC.NumberOfFloors.Should().Be(databaseAC.NumberOfFloors);
+            domainAC.Heating.Should().Be(databaseAC.Heating);
+            domainAC.PropertyFactor.Should().Be(databaseAC.PropertyFactor);
+            domainAC.ArchitecturalType.Should().Be(databaseAC.ArchitecturalType);
+            domainAC.AccessibilityComments.Should().Be(databaseAC.AccessibilityComments);
+            domainAC.NumberOfBedSpaces.Should().Be(databaseAC.NumberOfBedSpaces);
+            domainAC.NumberOfCots.Should().Be(databaseAC.NumberOfCots);
+            domainAC.SleepingArrangementNotes.Should().Be(databaseAC.SleepingArrangementNotes);
+            domainAC.NumberOfShowers.Should().Be(databaseAC.NumberOfShowers);
+            domainAC.KitchenNotes.Should().Be(databaseAC.KitchenNotes);
+            domainAC.IsStepFree.Should().Be(databaseAC.IsStepFree);
+            domainAC.BathroomNotes.Should().Be(databaseAC.BathroomNotes);
+            domainAC.LivingRoomNotes.Should().Be(databaseAC.LivingRoomNotes);
+        }
+
+        // These assertions are the same now, but in general case they won't be (Calculated fields, Excluded fields, etc).
+        private void StrictAssertDomainToDatabaseAssetCharacteristicMapping(AssetCharacteristics domainAC, AssetCharacteristicsDb databaseAC)
+        {
+            databaseAC.NumberOfBedrooms.Should().Be(domainAC.NumberOfBedrooms);
+            databaseAC.NumberOfSingleBeds.Should().Be(domainAC.NumberOfSingleBeds);
+            databaseAC.NumberOfDoubleBeds.Should().Be(domainAC.NumberOfDoubleBeds);
+            databaseAC.NumberOfLifts.Should().Be(domainAC.NumberOfLifts);
+            databaseAC.NumberOfLivingRooms.Should().Be(domainAC.NumberOfLivingRooms);
+            databaseAC.WindowType.Should().Be(domainAC.WindowType);
+            databaseAC.YearConstructed.Should().Be(domainAC.YearConstructed);
+            databaseAC.AssetPropertyFolderLink.Should().Be(domainAC.AssetPropertyFolderLink);
+            databaseAC.EpcExpiryDate.Should().Be(domainAC.EpcExpiryDate);
+            databaseAC.FireSafetyCertificateExpiryDate.Should().Be(domainAC.FireSafetyCertificateExpiryDate);
+            databaseAC.GasSafetyCertificateExpiryDate.Should().Be(domainAC.GasSafetyCertificateExpiryDate);
+            databaseAC.ElecCertificateExpiryDate.Should().Be(domainAC.ElecCertificateExpiryDate);
+            databaseAC.HasStairs.Should().Be(domainAC.HasStairs);
+            databaseAC.NumberOfStairs.Should().Be(domainAC.NumberOfStairs);
+            databaseAC.HasRampAccess.Should().Be(domainAC.HasRampAccess);
+            databaseAC.HasCommunalAreas.Should().Be(domainAC.HasCommunalAreas);
+            databaseAC.HasPrivateBathroom.Should().Be(domainAC.HasPrivateBathroom);
+            databaseAC.NumberOfBathrooms.Should().Be(domainAC.NumberOfBathrooms);
+            databaseAC.BathroomFloor.Should().Be(domainAC.BathroomFloor);
+            databaseAC.HasPrivateKitchen.Should().Be(domainAC.HasPrivateKitchen);
+            databaseAC.NumberOfKitchens.Should().Be(domainAC.NumberOfKitchens);
+            databaseAC.Kitchenfloor.Should().Be(domainAC.Kitchenfloor);
+            databaseAC.AlertSystemExpiryDate.Should().Be(domainAC.AlertSystemExpiryDate);
+            databaseAC.EpcScore.Should().Be(domainAC.EpcScore);
+            databaseAC.NumberOfFloors.Should().Be(domainAC.NumberOfFloors);
+            databaseAC.Heating.Should().Be(domainAC.Heating);
+            databaseAC.PropertyFactor.Should().Be(domainAC.PropertyFactor);
+            databaseAC.ArchitecturalType.Should().Be(domainAC.ArchitecturalType);
+            databaseAC.AccessibilityComments.Should().Be(domainAC.AccessibilityComments);
+            databaseAC.NumberOfBedSpaces.Should().Be(domainAC.NumberOfBedSpaces);
+            databaseAC.NumberOfCots.Should().Be(domainAC.NumberOfCots);
+            databaseAC.SleepingArrangementNotes.Should().Be(domainAC.SleepingArrangementNotes);
+            databaseAC.NumberOfShowers.Should().Be(domainAC.NumberOfShowers);
+            databaseAC.KitchenNotes.Should().Be(domainAC.KitchenNotes);
+            databaseAC.IsStepFree.Should().Be(domainAC.IsStepFree);
+            databaseAC.BathroomNotes.Should().Be(domainAC.BathroomNotes);
+            databaseAC.LivingRoomNotes.Should().Be(domainAC.LivingRoomNotes);
+        }
+
+        [Fact]
+        public void AssetCharacteristicsMapsFromDatabaseToDomain()
+        {
+            // arrange
+            var databaseAC = _fixture.Create<AssetCharacteristicsDb>();
+
+            // act
+            var domainAC = databaseAC.ToDomain();
+
+            // assert
+            StrictAssertDatabaseToDomainAssetCharacteristicMapping(databaseAC, domainAC);
+        }
+
+        [Fact]
+        public void AssetCharacteristicsMapsFromDomainToDatabase()
+        {
+            // arrange
+            var domainAC = _fixture.Create<AssetCharacteristics>();
+
+            // act
+            var databaseAC = domainAC.ToDatabase();
+
+            // assert
+            StrictAssertDomainToDatabaseAssetCharacteristicMapping(domainAC, databaseAC);
+        }
+
+        [Fact]
+        public void GivenAssetCharacteristicsIsNullWhenMappedFromDomainToDatabaseLayersThenItStaysNull()
+        {
+            // arrange
+            AssetCharacteristics domainAC = null;
+
+            // act
+            var databaseAC = domainAC.ToDatabase();
+
+            // assert
+            databaseAC.Should().BeNull();
+        }
+
+        [Fact]
+        public void GivenAssetCharacteristicsIsNullWhenMappedFromDatabaseToDomainLayersThenItStaysNull()
+        {
+            // arrange
+            AssetCharacteristicsDb databaseAC = null;
+
+            // act
+            var domainAC = databaseAC.ToDomain();
+
+            // assert
+            domainAC.Should().BeNull();
+        }
+
+        [Fact]
+        public void AssetCharacteristicsFromDomainToDatabaseMappingIsTriggeredByTheParentAssetObjectMapping()
+        {
+            // arrange
+            var domainAsset = _fixture.Create<AssetDomain>();
+            var expectedDatabaseAC = domainAsset.AssetCharacteristics.ToDatabase();
+
+            // act
+            var databaseAsset = domainAsset.ToDatabase();
+
+            // assert
+            // Using 'BeEquivalent' here, but not before because here we're comparing 2 objects that are part of the same layer: Database.
+            databaseAsset.AssetCharacteristics.Should().BeEquivalentTo(expectedDatabaseAC);
+        }
+
+        [Fact]
+        public void AssetCharacteristicsFromDatabaseToDomainMappingIsTriggeredByTheParentAssetObjectMapping()
+        {
+            // arrange
+            var databaseAsset = _fixture.Create<AssetDb>();
+            var expectedDomainAC = databaseAsset.AssetCharacteristics.ToDomain();
+
+            // act
+            var domainAsset = databaseAsset.ToDomain();
+
+            // assert
+            // Using 'BeEquivalent' here, but not before because here we're comparing 2 objects that are part of the same layer: Domain.
+            domainAsset.AssetCharacteristics.Should().BeEquivalentTo(expectedDomainAC);
+        }
+        #endregion
     }
 }

--- a/Hackney.Shared.Asset.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.Asset.Tests/Factories/EntityFactoryTest.cs
@@ -109,8 +109,16 @@ namespace Hackney.Shared.Asset.Tests.Factories
         }
 
         #region Asset Characteristics
-        private void StrictAssertDatabaseToDomainAssetCharacteristicMapping(AssetCharacteristicsDb databaseAC, AssetCharacteristics domainAC)
+        [Fact]
+        public void AssetCharacteristicsMapsFromDatabaseToDomain()
         {
+            // arrange
+            var databaseAC = _fixture.Create<AssetCharacteristicsDb>();
+
+            // act
+            var domainAC = databaseAC.ToDomain();
+
+            // assert
             domainAC.NumberOfBedrooms.Should().Be(databaseAC.NumberOfBedrooms);
             domainAC.NumberOfSingleBeds.Should().Be(databaseAC.NumberOfSingleBeds);
             domainAC.NumberOfDoubleBeds.Should().Be(databaseAC.NumberOfDoubleBeds);
@@ -150,9 +158,16 @@ namespace Hackney.Shared.Asset.Tests.Factories
             domainAC.LivingRoomNotes.Should().Be(databaseAC.LivingRoomNotes);
         }
 
-        // These assertions are the same now, but in general case they won't be (Calculated fields, Excluded fields, etc).
-        private void StrictAssertDomainToDatabaseAssetCharacteristicMapping(AssetCharacteristics domainAC, AssetCharacteristicsDb databaseAC)
+        [Fact]
+        public void AssetCharacteristicsMapsFromDomainToDatabase()
         {
+            // arrange
+            var domainAC = _fixture.Create<AssetCharacteristics>();
+
+            // act
+            var databaseAC = domainAC.ToDatabase();
+
+            // assert
             databaseAC.NumberOfBedrooms.Should().Be(domainAC.NumberOfBedrooms);
             databaseAC.NumberOfSingleBeds.Should().Be(domainAC.NumberOfSingleBeds);
             databaseAC.NumberOfDoubleBeds.Should().Be(domainAC.NumberOfDoubleBeds);
@@ -190,32 +205,6 @@ namespace Hackney.Shared.Asset.Tests.Factories
             databaseAC.IsStepFree.Should().Be(domainAC.IsStepFree);
             databaseAC.BathroomNotes.Should().Be(domainAC.BathroomNotes);
             databaseAC.LivingRoomNotes.Should().Be(domainAC.LivingRoomNotes);
-        }
-
-        [Fact]
-        public void AssetCharacteristicsMapsFromDatabaseToDomain()
-        {
-            // arrange
-            var databaseAC = _fixture.Create<AssetCharacteristicsDb>();
-
-            // act
-            var domainAC = databaseAC.ToDomain();
-
-            // assert
-            StrictAssertDatabaseToDomainAssetCharacteristicMapping(databaseAC, domainAC);
-        }
-
-        [Fact]
-        public void AssetCharacteristicsMapsFromDomainToDatabase()
-        {
-            // arrange
-            var domainAC = _fixture.Create<AssetCharacteristics>();
-
-            // act
-            var databaseAC = domainAC.ToDatabase();
-
-            // assert
-            StrictAssertDomainToDatabaseAssetCharacteristicMapping(domainAC, databaseAC);
         }
 
         [Fact]

--- a/Hackney.Shared.Asset.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.Asset.Tests/Factories/ResponseFactoryTest.cs
@@ -4,6 +4,7 @@ using AutoFixture;
 using FluentAssertions;
 using Xunit;
 using AssetDomain = Hackney.Shared.Asset.Domain.Asset;
+using Hackney.Shared.Asset.Boundary.Response;
 
 namespace Hackney.Shared.Asset.Tests.Factories
 {
@@ -44,5 +45,89 @@ namespace Hackney.Shared.Asset.Tests.Factories
             var response = domain.ToResponse();
             domain.Should().BeEquivalentTo(response);
         }
+
+        #region Asset Characteristics
+        private void StrictAssertDomainToPresentationAssetCharacteristicsMapping(AssetCharacteristics domainAC, AssetCharacteristicsResponse presentationAC)
+        {
+            presentationAC.NumberOfBedrooms.Should().Be(domainAC.NumberOfBedrooms);
+            presentationAC.NumberOfSingleBeds.Should().Be(domainAC.NumberOfSingleBeds);
+            presentationAC.NumberOfDoubleBeds.Should().Be(domainAC.NumberOfDoubleBeds);
+            presentationAC.NumberOfLifts.Should().Be(domainAC.NumberOfLifts);
+            presentationAC.NumberOfLivingRooms.Should().Be(domainAC.NumberOfLivingRooms);
+            presentationAC.WindowType.Should().Be(domainAC.WindowType);
+            presentationAC.YearConstructed.Should().Be(domainAC.YearConstructed);
+            presentationAC.AssetPropertyFolderLink.Should().Be(domainAC.AssetPropertyFolderLink);
+            presentationAC.EpcExpiryDate.Should().Be(domainAC.EpcExpiryDate);
+            presentationAC.FireSafetyCertificateExpiryDate.Should().Be(domainAC.FireSafetyCertificateExpiryDate);
+            presentationAC.GasSafetyCertificateExpiryDate.Should().Be(domainAC.GasSafetyCertificateExpiryDate);
+            presentationAC.ElecCertificateExpiryDate.Should().Be(domainAC.ElecCertificateExpiryDate);
+            presentationAC.HasStairs.Should().Be(domainAC.HasStairs);
+            presentationAC.NumberOfStairs.Should().Be(domainAC.NumberOfStairs);
+            presentationAC.HasRampAccess.Should().Be(domainAC.HasRampAccess);
+            presentationAC.HasCommunalAreas.Should().Be(domainAC.HasCommunalAreas);
+            presentationAC.HasPrivateBathroom.Should().Be(domainAC.HasPrivateBathroom);
+            presentationAC.NumberOfBathrooms.Should().Be(domainAC.NumberOfBathrooms);
+            presentationAC.BathroomFloor.Should().Be(domainAC.BathroomFloor);
+            presentationAC.HasPrivateKitchen.Should().Be(domainAC.HasPrivateKitchen);
+            presentationAC.NumberOfKitchens.Should().Be(domainAC.NumberOfKitchens);
+            presentationAC.Kitchenfloor.Should().Be(domainAC.Kitchenfloor);
+            presentationAC.AlertSystemExpiryDate.Should().Be(domainAC.AlertSystemExpiryDate);
+            presentationAC.EpcScore.Should().Be(domainAC.EpcScore);
+            presentationAC.NumberOfFloors.Should().Be(domainAC.NumberOfFloors);
+            presentationAC.Heating.Should().Be(domainAC.Heating);
+            presentationAC.PropertyFactor.Should().Be(domainAC.PropertyFactor);
+            presentationAC.ArchitecturalType.Should().Be(domainAC.ArchitecturalType);
+            presentationAC.AccessibilityComments.Should().Be(domainAC.AccessibilityComments);
+            presentationAC.NumberOfBedSpaces.Should().Be(domainAC.NumberOfBedSpaces);
+            presentationAC.NumberOfCots.Should().Be(domainAC.NumberOfCots);
+            presentationAC.SleepingArrangementNotes.Should().Be(domainAC.SleepingArrangementNotes);
+            presentationAC.NumberOfShowers.Should().Be(domainAC.NumberOfShowers);
+            presentationAC.KitchenNotes.Should().Be(domainAC.KitchenNotes);
+            presentationAC.IsStepFree.Should().Be(domainAC.IsStepFree);
+            presentationAC.BathroomNotes.Should().Be(domainAC.BathroomNotes);
+            presentationAC.LivingRoomNotes.Should().Be(domainAC.LivingRoomNotes);
+        }
+
+        [Fact]
+        public void AssetCharacteristicsMapsFromDomainToDatabase()
+        {
+            // arrange
+            var domainAC = _fixture.Create<AssetCharacteristics>();
+
+            // act
+            var presentationAC = domainAC.ToResponse();
+
+            // assert
+            StrictAssertDomainToPresentationAssetCharacteristicsMapping(domainAC, presentationAC);
+        }
+
+        [Fact]
+        public void GivenAssetCharacteristicsIsNullWhenMappedFromDomainToPresentationThenItStaysNull()
+        {
+            // arrange
+            AssetCharacteristics domainAC = null;
+
+            // act
+            var presentationAC = domainAC.ToResponse();
+
+            // assert
+            presentationAC.Should().BeNull();
+        }
+
+        [Fact]
+        public void AssetCharacteristicsFromDomainToDatabaseMappingIsTriggeredByTheParentAssetObjectMapping()
+        {
+            // arrange
+            var domainAsset = _fixture.Create<AssetDomain>();
+            var expectedPresentationC = domainAsset.AssetCharacteristics.ToResponse();
+
+            // act
+            var presentationAsset = domainAsset.ToResponse();
+
+            // assert
+            // Using 'BeEquivalent' here, but not before because here we're comparing 2 objects that are part of the same layer: Presentation.
+            presentationAsset.AssetCharacteristics.Should().BeEquivalentTo(expectedPresentationC);
+        }
+        #endregion
     }
 }

--- a/Hackney.Shared.Asset.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.Asset.Tests/Factories/ResponseFactoryTest.cs
@@ -47,8 +47,16 @@ namespace Hackney.Shared.Asset.Tests.Factories
         }
 
         #region Asset Characteristics
-        private void StrictAssertDomainToPresentationAssetCharacteristicsMapping(AssetCharacteristics domainAC, AssetCharacteristicsResponse presentationAC)
+        [Fact]
+        public void AssetCharacteristicsMapsFromDomainToDatabase()
         {
+            // arrange
+            var domainAC = _fixture.Create<AssetCharacteristics>();
+
+            // act
+            var presentationAC = domainAC.ToResponse();
+
+            // assert
             presentationAC.NumberOfBedrooms.Should().Be(domainAC.NumberOfBedrooms);
             presentationAC.NumberOfSingleBeds.Should().Be(domainAC.NumberOfSingleBeds);
             presentationAC.NumberOfDoubleBeds.Should().Be(domainAC.NumberOfDoubleBeds);
@@ -86,19 +94,6 @@ namespace Hackney.Shared.Asset.Tests.Factories
             presentationAC.IsStepFree.Should().Be(domainAC.IsStepFree);
             presentationAC.BathroomNotes.Should().Be(domainAC.BathroomNotes);
             presentationAC.LivingRoomNotes.Should().Be(domainAC.LivingRoomNotes);
-        }
-
-        [Fact]
-        public void AssetCharacteristicsMapsFromDomainToDatabase()
-        {
-            // arrange
-            var domainAC = _fixture.Create<AssetCharacteristics>();
-
-            // act
-            var presentationAC = domainAC.ToResponse();
-
-            // assert
-            StrictAssertDomainToPresentationAssetCharacteristicsMapping(domainAC, presentationAC);
         }
 
         [Fact]

--- a/Hackney.Shared.Asset/Boundary/Response/AssetCharasteristicsResponse.cs
+++ b/Hackney.Shared.Asset/Boundary/Response/AssetCharasteristicsResponse.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Hackney.Shared.Asset.Boundary.Response
+{
+    public class AssetCharacteristicsResponse
+    {
+        public int? NumberOfBedrooms { get; set; }
+        public int? NumberOfSingleBeds { get; set; }
+        public int? NumberOfDoubleBeds { get; set; }
+        public int? NumberOfLifts { get; set; }
+        public int? NumberOfLivingRooms { get; set; }
+        public string WindowType { get; set; }
+        public string YearConstructed { get; set; }
+        public string AssetPropertyFolderLink { get; set; }
+        public DateTime? EpcExpiryDate { get; set; }
+        public DateTime? FireSafetyCertificateExpiryDate { get; set; }
+        public DateTime? GasSafetyCertificateExpiryDate { get; set; }
+        public DateTime? ElecCertificateExpiryDate { get; set; }
+        public bool? HasStairs { get; set; }
+        public int? NumberOfStairs { get; set; }
+        public bool? HasRampAccess { get; set; }
+        public bool? HasCommunalAreas { get; set; }
+        public bool? HasPrivateBathroom { get; set; }
+        public int? NumberOfBathrooms { get; set; }
+        public string BathroomFloor { get; set; }
+        public bool? HasPrivateKitchen { get; set; }
+        public int? NumberOfKitchens { get; set; }
+        public string Kitchenfloor { get; set; }
+        public DateTime? AlertSystemExpiryDate { get; set; }
+        public string EpcScore { get; set; }
+        public int? NumberOfFloors { get; set; }
+        public string Heating { get; set; } 
+        public float? PropertyFactor { get; set; }
+        public string ArchitecturalType { get; set; }
+        public string AccessibilityComments { get; set; }
+        public int? NumberOfBedSpaces { get; set; }
+        public int? NumberOfCots { get; set; }
+        public string SleepingArrangementNotes { get; set; }
+        public int? NumberOfShowers { get; set; }
+        public string KitchenNotes { get; set; }
+        public bool? IsStepFree { get; set; }
+        public string BathroomNotes { get; set; }
+        public string LivingRoomNotes { get; set; }
+    }
+}

--- a/Hackney.Shared.Asset/Boundary/Response/AssetResponseObject.cs
+++ b/Hackney.Shared.Asset/Boundary/Response/AssetResponseObject.cs
@@ -16,7 +16,7 @@ namespace Hackney.Shared.Asset.Boundary.Response
         public AssetLocation AssetLocation { get; set; }
         public AssetAddress AssetAddress { get; set; }
         public AssetManagement AssetManagement { get; set; }
-        public AssetCharacteristics AssetCharacteristics { get; set; }
+        public AssetCharacteristicsResponse AssetCharacteristics { get; set; }
         public AssetTenureResponseObject Tenure { get; set; }
         public List<PatchesResponseObject?> Patches { get; set; }
         public int? VersionNumber { get; set; }

--- a/Hackney.Shared.Asset/Domain/AssetCharacteristics.cs
+++ b/Hackney.Shared.Asset/Domain/AssetCharacteristics.cs
@@ -5,6 +5,8 @@ namespace Hackney.Shared.Asset.Domain
     public class AssetCharacteristics
     {
         public int? NumberOfBedrooms { get; set; }
+        public int? NumberOfSingleBeds { get; set; }
+        public int? NumberOfDoubleBeds { get; set; }
         public int? NumberOfLifts { get; set; }
         public int? NumberOfLivingRooms { get; set; }
         public string WindowType { get; set; }
@@ -27,6 +29,9 @@ namespace Hackney.Shared.Asset.Domain
         public DateTime? AlertSystemExpiryDate { get; set; }
         public string EpcScore { get; set; }
         public int? NumberOfFloors { get; set; }
+        public string Heating { get; set; } 
+        public float? PropertyFactor { get; set; }
+        public string ArchitecturalType { get; set; }
         public string AccessibilityComments { get; set; }
         public int? NumberOfBedSpaces { get; set; }
         public int? NumberOfCots { get; set; }
@@ -38,4 +43,3 @@ namespace Hackney.Shared.Asset.Domain
         public string LivingRoomNotes { get; set; }
     }
 }
-

--- a/Hackney.Shared.Asset/Factories/EntityFactory.cs
+++ b/Hackney.Shared.Asset/Factories/EntityFactory.cs
@@ -27,12 +27,106 @@ namespace Hackney.Shared.Asset.Factories
                 AssetLocation = databaseEntity.AssetLocation,
                 AssetAddress = databaseEntity.AssetAddress,
                 AssetManagement = databaseEntity.AssetManagement,
-                AssetCharacteristics = databaseEntity.AssetCharacteristics,
+                AssetCharacteristics = databaseEntity.AssetCharacteristics.ToDomain(),
                 Tenure = databaseEntity.Tenure.ToDomain(),
                 VersionNumber = databaseEntity.VersionNumber,
                 Patches = databaseEntity.Patches?.ToDomain()
             };
         }
+
+        # region Asset Characteristics
+        public static AssetCharacteristics ToDomain(this AssetCharacteristicsDb databaseEntity)
+        {
+            if (databaseEntity is null) return null;
+
+            return new AssetCharacteristics
+            {
+                NumberOfBedrooms = databaseEntity.NumberOfBedrooms,
+                NumberOfSingleBeds = databaseEntity.NumberOfSingleBeds,
+                NumberOfDoubleBeds = databaseEntity.NumberOfDoubleBeds,
+                NumberOfLifts = databaseEntity.NumberOfLifts,
+                NumberOfLivingRooms = databaseEntity.NumberOfLivingRooms,
+                WindowType = databaseEntity.WindowType,
+                YearConstructed = databaseEntity.YearConstructed,
+                AssetPropertyFolderLink = databaseEntity.AssetPropertyFolderLink,
+                EpcExpiryDate = databaseEntity.EpcExpiryDate,
+                FireSafetyCertificateExpiryDate = databaseEntity.FireSafetyCertificateExpiryDate,
+                GasSafetyCertificateExpiryDate = databaseEntity.GasSafetyCertificateExpiryDate,
+                ElecCertificateExpiryDate = databaseEntity.ElecCertificateExpiryDate,
+                HasStairs = databaseEntity.HasStairs,
+                NumberOfStairs = databaseEntity.NumberOfStairs,
+                HasRampAccess = databaseEntity.HasRampAccess,
+                HasCommunalAreas = databaseEntity.HasCommunalAreas,
+                HasPrivateBathroom = databaseEntity.HasPrivateBathroom,
+                NumberOfBathrooms = databaseEntity.NumberOfBathrooms,
+                BathroomFloor = databaseEntity.BathroomFloor,
+                HasPrivateKitchen = databaseEntity.HasPrivateKitchen,
+                NumberOfKitchens = databaseEntity.NumberOfKitchens,
+                Kitchenfloor = databaseEntity.Kitchenfloor,
+                AlertSystemExpiryDate = databaseEntity.AlertSystemExpiryDate,
+                EpcScore = databaseEntity.EpcScore,
+                NumberOfFloors = databaseEntity.NumberOfFloors,
+                Heating = databaseEntity.Heating, 
+                PropertyFactor = databaseEntity.PropertyFactor,
+                ArchitecturalType = databaseEntity.ArchitecturalType,
+                AccessibilityComments = databaseEntity.AccessibilityComments,
+                NumberOfBedSpaces = databaseEntity.NumberOfBedSpaces,
+                NumberOfCots = databaseEntity.NumberOfCots,
+                SleepingArrangementNotes = databaseEntity.SleepingArrangementNotes,
+                NumberOfShowers = databaseEntity.NumberOfShowers,
+                KitchenNotes = databaseEntity.KitchenNotes,
+                IsStepFree = databaseEntity.IsStepFree,
+                BathroomNotes = databaseEntity.BathroomNotes,
+                LivingRoomNotes = databaseEntity.LivingRoomNotes
+            };
+        }
+
+        public static AssetCharacteristicsDb ToDatabase(this AssetCharacteristics domainEntity)
+        {
+            if (domainEntity is null) return null;
+
+            return new AssetCharacteristicsDb
+            {
+                NumberOfBedrooms = domainEntity.NumberOfBedrooms,
+                NumberOfSingleBeds = domainEntity.NumberOfSingleBeds,
+                NumberOfDoubleBeds = domainEntity.NumberOfDoubleBeds,
+                NumberOfLifts = domainEntity.NumberOfLifts,
+                NumberOfLivingRooms = domainEntity.NumberOfLivingRooms,
+                WindowType = domainEntity.WindowType,
+                YearConstructed = domainEntity.YearConstructed,
+                AssetPropertyFolderLink = domainEntity.AssetPropertyFolderLink,
+                EpcExpiryDate = domainEntity.EpcExpiryDate,
+                FireSafetyCertificateExpiryDate = domainEntity.FireSafetyCertificateExpiryDate,
+                GasSafetyCertificateExpiryDate = domainEntity.GasSafetyCertificateExpiryDate,
+                ElecCertificateExpiryDate = domainEntity.ElecCertificateExpiryDate,
+                HasStairs = domainEntity.HasStairs,
+                NumberOfStairs = domainEntity.NumberOfStairs,
+                HasRampAccess = domainEntity.HasRampAccess,
+                HasCommunalAreas = domainEntity.HasCommunalAreas,
+                HasPrivateBathroom = domainEntity.HasPrivateBathroom,
+                NumberOfBathrooms = domainEntity.NumberOfBathrooms,
+                BathroomFloor = domainEntity.BathroomFloor,
+                HasPrivateKitchen = domainEntity.HasPrivateKitchen,
+                NumberOfKitchens = domainEntity.NumberOfKitchens,
+                Kitchenfloor = domainEntity.Kitchenfloor,
+                AlertSystemExpiryDate = domainEntity.AlertSystemExpiryDate,
+                EpcScore = domainEntity.EpcScore,
+                NumberOfFloors = domainEntity.NumberOfFloors,
+                Heating = domainEntity.Heating, 
+                PropertyFactor = domainEntity.PropertyFactor,
+                ArchitecturalType = domainEntity.ArchitecturalType,
+                AccessibilityComments = domainEntity.AccessibilityComments,
+                NumberOfBedSpaces = domainEntity.NumberOfBedSpaces,
+                NumberOfCots = domainEntity.NumberOfCots,
+                SleepingArrangementNotes = domainEntity.SleepingArrangementNotes,
+                NumberOfShowers = domainEntity.NumberOfShowers,
+                KitchenNotes = domainEntity.KitchenNotes,
+                IsStepFree = domainEntity.IsStepFree,
+                BathroomNotes = domainEntity.BathroomNotes,
+                LivingRoomNotes = domainEntity.LivingRoomNotes
+            };
+        }
+        #endregion
 
         public static AssetTenure ToDomain(this AssetTenureDb databaseEntity)
         {
@@ -68,7 +162,7 @@ namespace Hackney.Shared.Asset.Factories
                 AssetLocation = domain.AssetLocation,
                 AssetAddress = domain.AssetAddress,
                 AssetManagement = domain.AssetManagement,
-                AssetCharacteristics = domain.AssetCharacteristics,
+                AssetCharacteristics = domain.AssetCharacteristics.ToDatabase(),
                 Tenure = domain.Tenure.ToDatabase(),
                 VersionNumber = domain.VersionNumber,
                 Patches = domain.Patches?.ToDatabase()

--- a/Hackney.Shared.Asset/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.Asset/Factories/ResponseFactory.cs
@@ -25,10 +25,56 @@ namespace Hackney.Shared.Asset.Factories
                 AssetLocation = domain.AssetLocation,
                 AssetAddress = domain.AssetAddress,
                 AssetManagement = domain.AssetManagement,
-                AssetCharacteristics = domain.AssetCharacteristics,
+                AssetCharacteristics = domain.AssetCharacteristics.ToResponse(),
                 Tenure = domain.Tenure.ToResponse(),
                 Patches = domain.Patches?.ToResponse(),
                 VersionNumber = domain.VersionNumber
+            };
+        }
+
+        public static AssetCharacteristicsResponse ToResponse(this AssetCharacteristics domainEntity)
+        {
+            if (domainEntity is null) return null;
+
+            return new AssetCharacteristicsResponse
+            {
+                NumberOfBedrooms = domainEntity.NumberOfBedrooms,
+                NumberOfSingleBeds = domainEntity.NumberOfSingleBeds,
+                NumberOfDoubleBeds = domainEntity.NumberOfDoubleBeds,
+                NumberOfLifts = domainEntity.NumberOfLifts,
+                NumberOfLivingRooms = domainEntity.NumberOfLivingRooms,
+                WindowType = domainEntity.WindowType,
+                YearConstructed = domainEntity.YearConstructed,
+                AssetPropertyFolderLink = domainEntity.AssetPropertyFolderLink,
+                EpcExpiryDate = domainEntity.EpcExpiryDate,
+                FireSafetyCertificateExpiryDate = domainEntity.FireSafetyCertificateExpiryDate,
+                GasSafetyCertificateExpiryDate = domainEntity.GasSafetyCertificateExpiryDate,
+                ElecCertificateExpiryDate = domainEntity.ElecCertificateExpiryDate,
+                HasStairs = domainEntity.HasStairs,
+                NumberOfStairs = domainEntity.NumberOfStairs,
+                HasRampAccess = domainEntity.HasRampAccess,
+                HasCommunalAreas = domainEntity.HasCommunalAreas,
+                HasPrivateBathroom = domainEntity.HasPrivateBathroom,
+                NumberOfBathrooms = domainEntity.NumberOfBathrooms,
+                BathroomFloor = domainEntity.BathroomFloor,
+                HasPrivateKitchen = domainEntity.HasPrivateKitchen,
+                NumberOfKitchens = domainEntity.NumberOfKitchens,
+                Kitchenfloor = domainEntity.Kitchenfloor,
+                AlertSystemExpiryDate = domainEntity.AlertSystemExpiryDate,
+                EpcScore = domainEntity.EpcScore,
+                NumberOfFloors = domainEntity.NumberOfFloors,
+                Heating = domainEntity.Heating, 
+                PropertyFactor = domainEntity.PropertyFactor,
+                ArchitecturalType = domainEntity.ArchitecturalType,
+                AccessibilityComments = domainEntity.AccessibilityComments,
+                NumberOfBedSpaces = domainEntity.NumberOfBedSpaces,
+                NumberOfCots = domainEntity.NumberOfCots,
+                SleepingArrangementNotes = domainEntity.SleepingArrangementNotes,
+                NumberOfShowers = domainEntity.NumberOfShowers,
+                KitchenNotes = domainEntity.KitchenNotes,
+                IsStepFree = domainEntity.IsStepFree,
+                BathroomNotes = domainEntity.BathroomNotes,
+                LivingRoomNotes = domainEntity.LivingRoomNotes
             };
         }
 

--- a/Hackney.Shared.Asset/Infrastructure/AssetCharacteristicsDb.cs
+++ b/Hackney.Shared.Asset/Infrastructure/AssetCharacteristicsDb.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Hackney.Shared.Asset.Infrastructure
+{
+    public class AssetCharacteristicsDb
+    {
+        public int? NumberOfBedrooms { get; set; }
+        public int? NumberOfSingleBeds { get; set; }
+        public int? NumberOfDoubleBeds { get; set; }
+        public int? NumberOfLifts { get; set; }
+        public int? NumberOfLivingRooms { get; set; }
+        public string WindowType { get; set; }
+        public string YearConstructed { get; set; }
+        public string AssetPropertyFolderLink { get; set; }
+        public DateTime? EpcExpiryDate { get; set; }
+        public DateTime? FireSafetyCertificateExpiryDate { get; set; }
+        public DateTime? GasSafetyCertificateExpiryDate { get; set; }
+        public DateTime? ElecCertificateExpiryDate { get; set; }
+        public bool? HasStairs { get; set; }
+        public int? NumberOfStairs { get; set; }
+        public bool? HasRampAccess { get; set; }
+        public bool? HasCommunalAreas { get; set; }
+        public bool? HasPrivateBathroom { get; set; }
+        public int? NumberOfBathrooms { get; set; }
+        public string BathroomFloor { get; set; }
+        public bool? HasPrivateKitchen { get; set; }
+        public int? NumberOfKitchens { get; set; }
+        public string Kitchenfloor { get; set; }
+        public DateTime? AlertSystemExpiryDate { get; set; }
+        public string EpcScore { get; set; }
+        public int? NumberOfFloors { get; set; }
+        public string Heating { get; set; } 
+        public float? PropertyFactor { get; set; }
+        public string ArchitecturalType { get; set; }
+        public string AccessibilityComments { get; set; }
+        public int? NumberOfBedSpaces { get; set; }
+        public int? NumberOfCots { get; set; }
+        public string SleepingArrangementNotes { get; set; }
+        public int? NumberOfShowers { get; set; }
+        public string KitchenNotes { get; set; }
+        public bool? IsStepFree { get; set; }
+        public string BathroomNotes { get; set; }
+        public string LivingRoomNotes { get; set; }
+    }
+}

--- a/Hackney.Shared.Asset/Infrastructure/AssetDb.cs
+++ b/Hackney.Shared.Asset/Infrastructure/AssetDb.cs
@@ -38,8 +38,8 @@ namespace Hackney.Shared.Asset.Infrastructure
         [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<AssetManagement>))]
         public AssetManagement AssetManagement { get; set; }
 
-        [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<AssetCharacteristics>))]
-        public AssetCharacteristics AssetCharacteristics { get; set; }
+        [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<AssetCharacteristicsDb>))]
+        public AssetCharacteristicsDb AssetCharacteristics { get; set; }
 
         [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<AssetTenureDb>))]
         public AssetTenureDb Tenure { get; set; }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: clean
+clean:
+	docker rm $$(docker ps -a --filter "status=exited" | grep hackney-shared-asset-test | grep -oE "^[[:xdigit:]]+")
+	docker rmi $$(docker images --filter "dangling=true" -q)
+
+.PHONY: test
+test:
+	-docker-compose build hackney-shared-asset-test && docker-compose run hackney-shared-asset-test
+	-make clean

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ For full details on how to use the package(s) within this repository please read
 
 ## Contributing
 
+### Running Tests Locally
+1. Create the `.env` file based on the `.env.sample` and then populate the values for the variable names listed there. To create the `.env` run:
+    ``` sh
+    cp .env.sample .env
+    ```
+2. Run the tests by running:
+    ``` sh
+    make test
+    ```
+
 ### Automated Versioning
 The pipeline automatically updates the package version number.
 


### PR DESCRIPTION
# What
 - Added extra fields to `AssetChacteristics` (AC) model.
 - Fixed the layer separation for the `AssetChacteristics`  schemas.
 - Set up an easy way to run tests locally.

# Why:
 - The extra fields that were added are needed by the users of the MMH application. The reason for some of the fields are described within [this sheet](https://docs.google.com/spreadsheets/d/1IzegajdwK_gCtpGFJF3t8eE0MOB-UfyaefTD1a8d9cs/edit?pli=1#gid=0) & the information about the fields is within [this sheet](https://docs.google.com/spreadsheets/d/1NbasBWpoOWJn9T2eiXwiUP3fNn3aVT8Faluy7Dyudys/edit?pli=1#gid=72716727).
 - Created the Database and Response entities for AC model to make it follow the Hackney Architecture. Plus this future proofs the solution should we decide to have Presentation diverge from the Database layer schema.
 - Set up easy tests run, so no one would need to either mess with docker commands, or to push to GH to see the test run results. 