### PR TITLE
Fix rentgroup enum

### DIFF
--- a/Hackney.Shared.Asset/Domain/Enums.cs
+++ b/Hackney.Shared.Asset/Domain/Enums.cs
@@ -37,6 +37,7 @@ namespace Hackney.Shared.Asset.Domain
         NewBuild
     }
 
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum RentGroup
     {
         GPS,


### PR DESCRIPTION
The RentGroup is saved as a 3-letter string in the DynamoDB record. However, no decorator has been specified on the enum in the shared Asset library. This means the deserializer attempts to read an integer from the field and consequently throws a `System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable`1[Hackney.Shared.Asset.Domain.RentGroup]. Path: $.rentGroup | LineNumber: 0 | BytePositionInLine: 106.`

Example: [here](https://london-borough-of-hackney.sentry.io/issues/4310243836/?query=is%3Aunresolved&referrer=issue-stream&stream_index=1)

So, add `JsonStringEnumConverter` attribute (similar to the other enum, AssetType, in the same class!)