### PR TITLE
MR-733 - Remove rule that prevents UPRN from being sent as an empty string

### DIFF
--- a/Hackney.Shared.Asset.Tests/Boundary/Validation/EditAssetAddressRequestValidatorTests.cs
+++ b/Hackney.Shared.Asset.Tests/Boundary/Validation/EditAssetAddressRequestValidatorTests.cs
@@ -22,19 +22,6 @@ namespace Hackney.Shared.Asset.Tests.Boundary.Validation
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void MissingUprnShouldErrorWithNoValue(string value)
-        {
-            var request = CreateValidRequest();
-            request.AssetAddress.Uprn = value;
-
-            var result = _sut.TestValidate(request);
-            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.Uprn)
-                .WithErrorCode(ErrorCodes.AssetAddressUprnEmptyOrInvalid);
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
         public void AddressLine1ShouldErrorWithNoValue(string value)
         {
             var request = CreateValidRequest();

--- a/Hackney.Shared.Asset/Boundary/Request/Validation/EditAssetAddressRequestValidator.cs
+++ b/Hackney.Shared.Asset/Boundary/Request/Validation/EditAssetAddressRequestValidator.cs
@@ -17,10 +17,6 @@ namespace Hackney.Shared.Asset.Boundary.Request.Validation
             RuleFor(x => x.AssetAddress).NotXssString()
                                         .WithErrorCode(ErrorCodes.XssFailure);
 
-            RuleFor(x => x.AssetAddress.Uprn).NotNull()
-                                             .NotEmpty()
-                                             .WithErrorCode(ErrorCodes.AssetAddressUprnEmptyOrInvalid);
-
             RuleFor(x => x.AssetAddress.Uprn).NotXssString()
                                              .WithErrorCode(ErrorCodes.XssFailure);
 


### PR DESCRIPTION
## Link to JIRA ticket

[Add a link to the JIRA ticket that the changes in this PR describe.](https://hackney.atlassian.net/jira/software/c/projects/MR/boards/88?modal=detail&selectedIssue=MR-733)

## Describe this PR

### *What is the problem we're trying to solve*

We're are going to allow editing of non-UPRN addresses. For this we're going to use the same endpoint in Asset API `PatchAssetAddress`, which expects an object of type `EditAssetAddressRequest`.

When we initially introduced this feature at the beginning of the year, a validator was also introduced, `EditAssetAddressRequestValidator`, in this repository. This, however, is now preventing us from editing addresses that have no UPRNs (regardless of whether this is `null` or `""`). The error we get is the following:
![image](https://github.com/LBHackney-IT/asset-shared/assets/70756861/59414fc6-7bd2-4e02-b6ad-712f69fb9b8d)

### *What changes have we introduced*

By removing the rule this PR aims to remove, we allow the UPRNs to be sent as an empty strings. 
I tested this by running Asset API locally, and completely removing the `EditAssetAddressRequestValidator` from Startup temporarily. 

This way the UPRN field will be treated as an optional field, in the same way as `AddressLine4`.

The validator is only used by Asset API, for this specific (Edit Asset Address) purpose so this change should not affect any other functionality (https://github.com/search?q=EditAssetAddressRequestValidator&type=code).

#### _Checklist_

- [x] Removed one of the two UPRN rules in `EditAssetAddressRequestValidator`

### *Follow up actions after merging PR*

Asset API's version of Asset Shared will need to be updated. 