### PR TITLE
Handle Invalid Enum Value when Deserializing Asset

### DIFF
--- a/Hackney.Shared.Asset.Tests/Serialization/SerializationTests.cs
+++ b/Hackney.Shared.Asset.Tests/Serialization/SerializationTests.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+using Hackney.Shared.Asset.Serialization;
+using Xunit;
+using Newtonsoft.Json;
+using FluentAssertions;
+
+namespace Hackney.Shared.Asset.Tests.Serialization
+{
+    [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum OldEnum
+    {
+        Dwelling
+    }
+
+    [Newtonsoft.Json.JsonConverter(typeof(SafeStringEnumConverter), NotFound)]
+    public enum NewEnum
+    {
+        Dwelling,
+        NotFound
+    }
+
+    public class TestModelOld
+    {
+        public OldEnum TestEnum { get; set; }
+        public string TestValue { get; set; }
+    }
+
+    public class TestModelNew
+    {
+        public NewEnum TestEnum { get; set; }
+        public string TestValue { get; set; }
+    }
+
+    public class SerializationTests
+    {
+        [Fact]
+        public async Task OldJsonConverter_WhenEnumExists_DeserializesJson()
+        {
+            // Arrange
+            var requestJson = "{\"TestValue\":\"Dummy Text\",\"TestEnum\":\"Dwelling\"}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<TestModelOld>(requestJson);
+
+            // Assert
+            result.TestEnum.Should().Be(OldEnum.Dwelling);
+        }
+
+        [Fact]
+        public async Task OldJsonConverter_WhenEnumDoesntExist_ThrowsException()
+        {
+            // Arrange
+            var requestJson = "{\"TestValue\":\"Dummy Text\",\"TestEnum\":\"InvalidEnum\"}";
+
+            // Act
+            Func<TestModelOld> func = () => JsonConvert.DeserializeObject<TestModelOld>(requestJson);
+
+            // Assert
+            func.Should().Throw<JsonSerializationException>();
+        }
+
+        [Fact]
+        public async Task NewJsonConverter_WhenEnumExists_DeserializesJson()
+        {
+            // Arrange
+            var requestJson = "{\"TestValue\":\"Dummy Text\",\"TestEnum\":\"Dwelling\"}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<TestModelNew>(requestJson);
+
+            // Assert
+            result.TestEnum.Should().Be(NewEnum.Dwelling);
+        }
+
+
+        [Fact]
+        public async Task NewJsonConverter_WhenEnumDoesntExist_UsesDefaultValue()
+        {
+            // Arrange
+            var requestJson = "{\"TestValue\":\"Dummy Text\",\"TestEnum\":\"Dxwellingg\"}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<TestModelNew>(requestJson);
+
+            // Assert
+            result.TestEnum.Should().Be(NewEnum.NotFound);
+        }
+
+
+        [Fact]
+        public async Task OldJsonConverter_WhenSerialized_ReturnsEnumAsNumber()
+        {
+            // Arrange
+            var model = new TestModelOld
+            {
+                TestEnum = OldEnum.Dwelling,
+                TestValue = "test"
+            };
+
+            // Act
+            var result = JsonConvert.SerializeObject(model);
+
+            // Assert
+            var expectedJson = $"{{\"TestEnum\":0,\"TestValue\":\"test\"}}";
+
+            result.Should().Be(expectedJson);
+        }
+
+        [Fact]
+        public async Task NewJsonConverter_WhenSerialized_ReturnsEnumAsString()
+        {
+            // Arrange
+            var model = new TestModelNew
+            {
+                TestEnum = NewEnum.Dwelling,
+                TestValue = "test"
+            };
+
+            // Act
+            var result = JsonConvert.SerializeObject(model);
+
+            // Assert
+            var expectedJson = $"{{\"TestEnum\":\"Dwelling\",\"TestValue\":\"test\"}}";
+
+            result.Should().Be(expectedJson);
+        }
+    }
+}

--- a/Hackney.Shared.Asset/Domain/Enums.cs
+++ b/Hackney.Shared.Asset/Domain/Enums.cs
@@ -4,6 +4,9 @@ using System.Text.Json.Serialization;
 
 namespace Hackney.Shared.Asset.Domain
 {
+
+    // If you add/modify any enum value, you must update this library in every project.
+    // Otherwise, the new value will default to NotFound
     [Newtonsoft.Json.JsonConverter(typeof(SafeStringEnumConverter), NotFound)]
     public enum AssetType
     {

--- a/Hackney.Shared.Asset/Domain/Enums.cs
+++ b/Hackney.Shared.Asset/Domain/Enums.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 
 namespace Hackney.Shared.Asset.Domain
 {
-
     // If you add/modify any enum value, you must update this library in every project.
     // Otherwise, the new value will default to NotFound
     [Newtonsoft.Json.JsonConverter(typeof(SafeStringEnumConverter), NotFound)]

--- a/Hackney.Shared.Asset/Domain/Enums.cs
+++ b/Hackney.Shared.Asset/Domain/Enums.cs
@@ -1,9 +1,10 @@
+using Hackney.Shared.Asset.Serialization;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
 namespace Hackney.Shared.Asset.Domain
 {
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [Newtonsoft.Json.JsonConverter(typeof(SafeStringEnumConverter), NotFound)]
     public enum AssetType
     {
         Block,
@@ -34,7 +35,8 @@ namespace Hackney.Shared.Asset.Domain
         SelfContainedBedsit,
         Maisonette,
         [EnumMember(Value = "New Build")]
-        NewBuild
+        NewBuild,
+        NotFound
     }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/Hackney.Shared.Asset/Serialization/SafeStringEnunConverter.cs
+++ b/Hackney.Shared.Asset/Serialization/SafeStringEnunConverter.cs
@@ -4,7 +4,8 @@ using System;
 
 namespace Hackney.Shared.Asset.Serialization
 {
-    // You must update this library in every project, otherwise you will not detect new enum values
+    // If you add/modify any enum value, you must update this library in every project.
+    // Otherwise, the new value will default to the default value
     public class SafeStringEnumConverter : StringEnumConverter
     {
         public object DefaultValue { get; }

--- a/Hackney.Shared.Asset/Serialization/SafeStringEnunConverter.cs
+++ b/Hackney.Shared.Asset/Serialization/SafeStringEnunConverter.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace Hackney.Shared.Asset.Serialization
 {
+    // You must update this library in every project, otherwise you will not detect new enum values
     public class SafeStringEnumConverter : StringEnumConverter
     {
         public object DefaultValue { get; }

--- a/Hackney.Shared.Asset/Serialization/SafeStringEnunConverter.cs
+++ b/Hackney.Shared.Asset/Serialization/SafeStringEnunConverter.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+
+namespace Hackney.Shared.Asset.Serialization
+{
+    public class SafeStringEnumConverter : StringEnumConverter
+    {
+        public object DefaultValue { get; }
+
+        public SafeStringEnumConverter(object defaultValue)
+        {
+            DefaultValue = defaultValue;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            try
+            {
+                return base.ReadJson(reader, objectType, existingValue, serializer);
+            }
+            catch
+            {
+                return DefaultValue;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Describe this PR

Integrations that deserialize the Asset class are at risk of breaking if an `AssetType` is used that doest exist. This caused the following exception in repairsAPI after deserializing data from the HousingSearchAPI:

![image](https://github.com/LBHackney-IT/asset-shared/assets/88662046/9b8ab50a-0bbb-4c79-8a6f-5ca2c54b2f91)

This PR mitigates this issue by implementing the class `SafeStringEnumConverter`. The class allows you to define a default value for the serializer if none are found. The class is used as follows:

```cs
[Newtonsoft.Json.JsonConverter(typeof(SafeStringEnumConverter), NotFound)]
public enum AssetType
{
...,
NotFound
}
```

For `AssetType`, I have added `NotFound` to be used as the default value.