### PR TITLE
TS-1131: Add RentGroup to EditAssetRequest

### DIFF
--- a/Hackney.Shared.Asset/Boundary/Request/EditAssetRequest.cs
+++ b/Hackney.Shared.Asset/Boundary/Request/EditAssetRequest.cs
@@ -11,7 +11,7 @@ namespace Hackney.Shared.Asset.Boundary.Request
         public string ParentAssetIds { get; set; }
         public string BoilerHouseId { get; set; }
         public bool IsActive { get; set; }
-        public RentGroup RentGroup { get; set; }
+        public RentGroup? RentGroup { get; set; }
         public AssetLocation AssetLocation { get; set; }
         public AssetManagement AssetManagement { get; set; }
         public AssetCharacteristics AssetCharacteristics { get; set; }

--- a/Hackney.Shared.Asset/Boundary/Request/EditAssetRequest.cs
+++ b/Hackney.Shared.Asset/Boundary/Request/EditAssetRequest.cs
@@ -11,6 +11,7 @@ namespace Hackney.Shared.Asset.Boundary.Request
         public string ParentAssetIds { get; set; }
         public string BoilerHouseId { get; set; }
         public bool IsActive { get; set; }
+        public RentGroup RentGroup { get; set; }
         public AssetLocation AssetLocation { get; set; }
         public AssetManagement AssetManagement { get; set; }
         public AssetCharacteristics AssetCharacteristics { get; set; }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1131

## Describe this PR

### *What is the problem we're trying to solve*

BTA needs to be able to edit information about the rent group.
This was already part of the package, only not included in the edit request 

### *What changes have we introduced*

Added RentGroup to EditAssetRequest

### *Follow up actions after merging PR*

We will need to update the package version on the Asset API