### PR TITLE
add IsPartOfTemporaryAccommodationBlock flag to AssetManagement

### DIFF
--- a/Hackney.Shared.Asset/Domain/AssetManagement.cs
+++ b/Hackney.Shared.Asset/Domain/AssetManagement.cs
@@ -18,6 +18,7 @@ namespace Hackney.Shared.Asset.Domain
         public string CouncilTaxLiability { get; set; }
         public bool? IsTemporaryAccomodation { get; set; }
         public bool? IsTemporaryAccommodationBlock { get; set; }
+        public bool? IsPartOfTemporaryAccommodationBlock { get; set; }
         public Guid? TemporaryAccommodationParentAssetId { get; set; }
         public bool? ReadyToLetDate { get; set; }
     }


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1921](https://hackney.atlassian.net/browse/TS-1921)

## Describe this PR

### *What is the problem we're trying to solve*

In Temporary Accommodation we need to be able to identify units that belong to a building by parent UPRN association, but are not treated in TA as part of a block. Blocks and standalone units have their own contracts, so it's important that we can manage standalone units independently regardless whether they have a parent UPRN or not.

### *What changes have we introduced*

Add new `IsPartOfTemporaryAccommodationBlock` flag to `AssetManagement` to indicate whether the asset belongs to a TA block. 

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x ] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A